### PR TITLE
Manage metrics exporters with Bolt

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
-# OSP Managed Prometheus
+# Bolt Managed Prometheus
 
-This module provides the plumbing and automation to set up a basic reference
-architecture for Open Source Puppet Server, PuppetDB, and Prometheus.
+This module provides the plumbing and automation to set up and maintain a
+Prometheus metrics collection stack including metrics exporters and relaying to
+Grafana Cloud.
 
 ![Workshop Architecture](.architecture.png)
 
@@ -19,35 +20,37 @@ architecture for Open Source Puppet Server, PuppetDB, and Prometheus.
 
 ## Description
 
-Using Vagrant and Bolt, bootstrap a monolithic Puppet instance with two nodes:
-`osp` and `prometheus`. This module will install and configure Puppet Server and
-PuppetDB on the `osp` node using
-[`theforeman-puppet`](https://forge.puppet.com/modules/theforeman/puppet/readme)
-module, configure `/etc/hosts` to ease communication between the nodes, and set
-up agents. Then, it configures [r10k](https://github.com/puppetlabs/r10k) to
-deploy a [special control
-repo](https://github.com/jameslikeslinux/osp-managed-prom-control-repo.git) containing
-roles and profiles to complete the Prometheus installation and configuration.
+Use [Bolt](https://www.puppet.com/docs/bolt/latest/bolt.html) to orchestrate
+the deployment of Prometheus and any number of metrics exporters at a customer
+site. This module wraps the
+[puppet-prometheus](https://forge.puppet.com/modules/puppet/prometheus/readme)
+module with Bolt plans and a Hiera configuration that will let you install and
+maintain these services from an administrative workstation.
 
 ## Setup
 
 ### What osp_managed_prom affects
 
-This module is primarily a [Bolt
-project](https://www.puppet.com/docs/bolt/latest/bolt.html) that targets the
-Vagrant instances that this module also provides. Exercise caution before
-attempting to apply this module to other resources.
+As this module mostly wraps a well-maintained community module, see the
+[upstream
+documentation](https://forge.puppet.com/modules/puppet/prometheus/readme#what-this-module-affects).
+Bolt will apply that module to the targets you configure with the data you
+supply.
 
 ### Setup Requirements
 
-This module requires a working [Vagrant](https://www.vagrantup.com/)
+Fork this module to a private repo if you want to commit a customer
+configuration. Traditionally, Hiera data exists independently of the code and
+the module, but for ease of deployment and management, we consolidate it here.
+
+For testing, this module requires a working [Vagrant](https://www.vagrantup.com/)
 installation. The `Vagrantfile` provided in this repo expects the libvirt
 backend. You may need to modify it to work with other backends, such as
 VirtualBox.
 
 ### Beginning with osp_managed_prom
 
-This module assumes two hosts named "osp" for the Puppet Server and
+This module assumes two hosts named "osp" for the (optional) Puppet Server and
 "prometheus" for the Prometheus server and establishes aliases as such, so you
 can call them whatever you want.
 
@@ -81,7 +84,7 @@ it how to connect.
 
 #### AWS
 
-Launch two Puppet-compatible instances and install Puppet Agent. Modify
+Launch two Puppet-compatible instances (i.e. most modern Linux distros). Modify
 `inventory-aws.yaml` to reflect actual IP addresses and usernames, but keep the
 names "osp" and "prometheus". We use `/etc/hosts` and the Puppet `certname` to
 effectively pin these names as aliases so that the customer's hostnames are
@@ -109,7 +112,7 @@ Prometheus instance and metrics exporters.
 #### Prometheus
 
 Prometheus is managed by the
-[`puppet/prometheus`](https://forge.puppet.com/modules/puppet/prometheus/readme)
+[`puppet-prometheus`](https://forge.puppet.com/modules/puppet/prometheus/readme)
 module and applied by Bolt. It will pull its configuration from Hiera.
 
 1. Copy the example site configuration and modify the remote write config for
@@ -136,6 +139,61 @@ Update the Hiera configurations and redeploy as needed.
 
 #### Metrics Exporters
 
+Metrics exporters are managed by the same 
+[`puppet-prometheus`](https://forge.puppet.com/modules/puppet/prometheus/readme)
+module. You can see a complete list of exporter types at
+https://github.com/voxpupuli/puppet-prometheus/tree/master/manifests. Click on
+the manifest to see all the parameters you can set to customize the (usually
+OK) defaults. Define any necessary parameters in Hiera, at the site level as
+above, or the node level:
+
+1. Create a file named like `data/foo.example.com.yaml` containing parameters like:
+   ```yaml
+   ---
+   prometheus::apache_exporter::scrape_uri: 'http://localhost:8080/server-status/?auto'
+   prometheus::node_exporter::scrape_port: 9101
+   ```
+   This file is excluded from Git by default. Use `git add -f` if you wish to
+   add it to your **forked and private** repo.
+2. Define a node configuration in the Bolt inventory modeled after the existing
+   "osp" and "prometheus" entries that uses the same name as the Hiera data
+   file.
+3. Apply the configuration:
+   ```
+   bolt plan run -i inventory-foo.yaml osp_managed_prom::prometheus::deploy_exporter \
+    -t foo.example.com,bar.example.com,... exporter=NAME
+   ```
+   where `NAME` is the exporter type, e.g., `apache`, `nginx_prometheus`,
+   `node`, `php_fpm`.
+
+Update the Hiera configurations and redeploy as needed.
+
+##### Example
+
+```
+> bolt plan run -i inventory-vagrant.yaml osp_managed_prom::prometheus::deploy_exporter -t prometheus exporter=node
+Starting: plan osp_managed_prom::prometheus::deploy_exporter
+Starting: install puppet and gather facts on prometheus
+Finished: install puppet and gather facts with 0 failures in 25.36 sec
+Starting: apply catalog on prometheus
+Finished: apply catalog with 0 failures in 28.01 sec
+prometheus: Notice: /Stage[main]/Prometheus::Config/File[prometheus.yaml]/content: content changed '{sha256}e2db4b4e4b5006330160dbe7e8c9ebff3be37f7e8459a3a4618a82ab75b99cfe' to '{sha256}74706a13b5e1a236910b54c20d11f20d98964afceb5319410c2451fe154ac83a'
+prometheus: Notice: /Stage[main]/Prometheus::Node_exporter/Prometheus::Daemon[node_exporter]/Archive[/tmp/node_exporter-1.0.1.tar.gz]/ensure: download archive from https://github.com/prometheus/node_exporter/releases/download/v1.0.1/node_exporter-1.0.1.linux-amd64.tar.gz to /tmp/node_exporter-1.0.1.tar.gz and extracted in /opt with cleanup
+prometheus: Notice: /Stage[main]/Prometheus::Node_exporter/Prometheus::Daemon[node_exporter]/File[/opt/node_exporter-1.0.1.linux-amd64/node_exporter]/owner: owner changed 3434 to 'root'
+prometheus: Notice: /Stage[main]/Prometheus::Node_exporter/Prometheus::Daemon[node_exporter]/File[/opt/node_exporter-1.0.1.linux-amd64/node_exporter]/group: group changed 3434 to 'root'
+prometheus: Notice: /Stage[main]/Prometheus::Node_exporter/Prometheus::Daemon[node_exporter]/File[/opt/node_exporter-1.0.1.linux-amd64/node_exporter]/mode: mode changed '0755' to '0555'
+prometheus: Notice: /Stage[main]/Prometheus::Node_exporter/Prometheus::Daemon[node_exporter]/File[/usr/local/bin/node_exporter]/ensure: created
+prometheus: Notice: /Stage[main]/Prometheus::Node_exporter/Prometheus::Daemon[node_exporter]/Group[node-exporter]/ensure: created
+prometheus: Notice: /Stage[main]/Prometheus::Node_exporter/Prometheus::Daemon[node_exporter]/User[node-exporter]/ensure: created
+prometheus: Notice: /Stage[main]/Prometheus::Service_reload/Exec[prometheus-reload]: Triggered 'refresh' from 1 event
+prometheus: Notice: /Stage[main]/Prometheus::Node_exporter/Prometheus::Daemon[node_exporter]/Systemd::Manage_unit[node_exporter.service]/Systemd::Unit_file[node_exporter.service]/File[/etc/systemd/system/node_exporter.service]/ensure: defined content as '{sha256}c548b39c93a3d73c52abfc887f3bec7ec8621de7bf457a24362deb45d20fabf5'
+prometheus: Notice: /Stage[main]/Prometheus::Node_exporter/Prometheus::Daemon[node_exporter]/Systemd::Manage_unit[node_exporter.service]/Systemd::Unit_file[node_exporter.service]/Systemd::Daemon_reload[node_exporter.service]/Exec[systemd-node_exporter.service-systemctl-daemon-reload]: Triggered 'refresh' from 1 event
+prometheus: Notice: /Stage[main]/Prometheus::Node_exporter/Prometheus::Daemon[node_exporter]/Service[node_exporter]/ensure: ensure changed 'stopped' to 'running'
+prometheus: Notice: Puppet: Applied catalog in 5.43 seconds
+Finished: plan osp_managed_prom::prometheus::deploy_exporter in 53.47 sec
+Plan completed successfully with no result
+```
+
 ### Bootstrap OSP infrastructure
 
 This process will kick off self-managing Puppet Server and
@@ -144,7 +202,7 @@ related components.
 
 1. Bootstrap the Puppet instance with the appropriate inventory config:
     ```
-    bolt plan run -i inventory-foo.yaml osp_managed_prom::bootstrap
+    bolt plan run -i inventory-foo.yaml osp_managed_prom::puppet::bootstrap
     ```
 2. Run Puppet on the `prometheus` node. This will complete the agent SSL bootstrap
    and install Prometheus based on the contents of the control repo.

--- a/plans/prometheus/deploy_exporter.pp
+++ b/plans/prometheus/deploy_exporter.pp
@@ -1,0 +1,20 @@
+# @summary Deploy Prometheus Metrics Exporter
+#
+# Install and configure a metrics exporter according to Hiera data.
+#
+# @param targets Nodes to install exporter on
+# @param exporter Name of the exporter to install
+#
+# @see https://github.com/voxpupuli/puppet-prometheus/tree/master/manifests
+plan osp_managed_prom::prometheus::deploy_exporter (
+  TargetSpec $targets,
+  String $exporter,
+) {
+  apply_prep($targets)
+
+  apply($targets) {
+    class { "prometheus::${exporter}_exporter":
+      # define parameter values in Hiera
+    }
+  }.osp_managed_prom::print_report
+}

--- a/plans/puppet/bootstrap.pp
+++ b/plans/puppet/bootstrap.pp
@@ -5,7 +5,7 @@
 #
 # @param osp Puppet Server node
 # @param prometheus Prometheus server node
-plan osp_managed_prom::bootstrap (
+plan osp_managed_prom::puppet::bootstrap (
   TargetSpec $osp        = 'osp',
   TargetSpec $prometheus = 'prometheus',
 ) {


### PR DESCRIPTION
Wrap the various exporter classes from the Vox Pupuli module with a Bolt plan that can read its configuration from Hiera data in this module. Update the README with deployment instructions for exporters, and generally reduce or minimize the prominence of Puppet Server and Vagrant in this application.